### PR TITLE
Fixed overflow in codeblocks

### DIFF
--- a/themes/stuartleeks1/assets/cache/css/codeblock.css
+++ b/themes/stuartleeks1/assets/cache/css/codeblock.css
@@ -21,7 +21,7 @@ pre code.hljs {
   border-top-right-radius: unset;
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: unset;
-  overflow: hidden;
+  overflow: auto hidden;
 }
 
 .highlight td:last-child pre, .highlight pre {


### PR DESCRIPTION
Hi there! Thank you very much for your post about [Forwarding the Windows SSH Agent to WSL](https://stuartleeks.com/posts/wsl-ssh-key-forward-to-windows/). It has been extremely useful.

The only problem I noticed is that sometimes the code on the page gets cut because `overflow: hidden` is set. Example:

![image](https://user-images.githubusercontent.com/7624090/104667585-655ab200-56a4-11eb-88f6-0005b4440474.png)

I'm not sure if the file I've changed is where I should make the change because I haven't worked with Hugo sites before, but I hope it is. This is an example of it working with the change applied locally with DevTools (line 23):

![image](https://user-images.githubusercontent.com/7624090/104667720-bb2f5a00-56a4-11eb-8167-5b5f59e470f4.png)